### PR TITLE
Fix more julia-0.5 deprecations

### DIFF
--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -1213,10 +1213,22 @@ end
 FileIO.save(f::File{format"JLD"}, value...; kwargs...) = error("Must supply a name for each variable")
 
 # load with just a filename returns a dictionary containing all the variables
-function FileIO.load(f::File{format"JLD"})
-    jldopen(FileIO.filename(f), "r") do file
-        Dict{String,Any}([var => read(file, var) for var in names(file)])
-    end
+if VERSION >= v"0.5.0-dev+4298"
+    # This cannot be parsed on julia-0.4, so we have to protect it
+    eval(parse("""
+        function FileIO.load(f::File{format"JLD"})
+            jldopen(FileIO.filename(f), "r") do file
+                Dict{String,Any}(var => read(file, var) for var in names(file))
+            end
+        end"""))
+else
+    # This generates a parser warning on julia-0.5 unless we protect it
+    eval(parse("""
+        function FileIO.load(f::File{format"JLD"})
+            jldopen(FileIO.filename(f), "r") do file
+                Dict{String,Any}([var => read(file, var) for var in names(file)])
+            end
+        end"""))
 end
 # When called with explicitly requested variable names, return each one
 function FileIO.load(f::File{format"JLD"}, varname::AbstractString)

--- a/src/jld_types.jl
+++ b/src/jld_types.jl
@@ -169,7 +169,7 @@ if !(isdefined(Core, :String) && isdefined(Core, :AbstractString))
     @compat function jlconvert(T::Union{Type{Compat.ASCIIString},Type{Compat.UTF8String}}, ::JldFile, ptr::Ptr)
         strptr = unsafe_load(convert(Ptr{Ptr{UInt8}}, ptr))
         n = Int(ccall(:strlen, Csize_t, (Ptr{UInt8},), strptr))
-        T(pointer_to_array(strptr, n, true))
+        T(unsafe_wrap(Array, strptr, n, true))
     end
 end
 
@@ -202,7 +202,7 @@ h5convert!(out::Ptr, ::JldFile, x::UTF16String, ::JldWriteSession) =
 
 function jlconvert(::Type{UTF16String}, ::JldFile, ptr::Ptr)
     hvl = unsafe_load(convert(Ptr{HDF5.Hvl_t}, ptr))
-    UTF16String(pointer_to_array(convert(Ptr{UInt16}, hvl.p), hvl.len, true))
+    UTF16String(unsafe_wrap(Array, convert(Ptr{UInt16}, hvl.p), hvl.len, true))
 end
 
 ## Symbols

--- a/test/jldtests.jl
+++ b/test/jldtests.jl
@@ -1,7 +1,7 @@
 using HDF5
 using JLD
 using Compat
-import Compat.String
+using Compat: String, view
 using Base.Test
 
 # Define variables of different types
@@ -87,7 +87,7 @@ bt = reinterpret(MyBT, @compat Int64(55))
 sa_asc = [:a, :b]
 sa_utf8 = [:α, :β]
 # SubArray (to test tuple type params)
-subarray = sub([1:5;], 1:5)
+subarray = view([1:5;], 1:5)
 # Array of empty tuples (to test tuple type params)
 arr_empty_tuple = (@compat Tuple{})[]
 immutable EmptyImmutable end


### PR DESCRIPTION
I'm not sure I see a more elegant solution for the parser deprecation warning.