### PR TITLE
Use LegacyStrings to support UFT16String

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.4
 HDF5
 Compat 0.8.0
 FileIO
+LegacyStrings  # for julia-0.5

--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -32,6 +32,9 @@ replacements = Any[]
 if isdefined(Core, :String) && isdefined(Core, :AbstractString)
     push!(replacements, :(s = replace(s, r"ASCIIString|UTF8String|ByteString", "String")))
 end
+if !isdefined(Base, :UTF16String)
+    push!(replacements, :(s = replace(s, "Base.UTF16String", "LegacyStrings.UTF16String")))
+end
 ex = Expr(:block, replacements...)
 @eval function julia_type(s::AbstractString)
     $ex

--- a/src/JLD00.jl
+++ b/src/JLD00.jl
@@ -3,7 +3,7 @@
 ###############################################
 
 module JLD00
-using HDF5, Compat
+using HDF5, Compat, LegacyStrings
 import Compat.String
 # Add methods to...
 import HDF5: close, dump, exists, file, getindex, setindex!, g_create, g_open, o_delete, name, names, read, size, write,

--- a/src/jld_types.jl
+++ b/src/jld_types.jl
@@ -1,3 +1,5 @@
+using LegacyStrings
+
 # Controls whether tuples and non-pointerfree immutables, which Julia
 # stores as references, are stored inline in compound types when
 # possible. Currently this is problematic because Julia fields of these

--- a/test/jldtests.jl
+++ b/test/jldtests.jl
@@ -1,6 +1,5 @@
-using HDF5
-using JLD
-using Compat
+using HDF5, JLD
+using Compat, LegacyStrings
 using Compat: String, view
 using Base.Test
 


### PR DESCRIPTION
UTF16String was removed from Base in Julia 0.5.