### PR TITLE
make this package JuliaLang/julia#265 ready

### DIFF
--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -10,7 +10,7 @@ import Compat.String
 # Add methods to...
 import HDF5: close, dump, exists, file, getindex, setindex!, g_create, g_open, o_delete, name, names, read, write,
              HDF5ReferenceObj, HDF5BitsKind, ismmappable, readmmap
-import Base: convert, length, endof, show, done, next, ndims, start, delete!, eltype, size, sizeof
+import Base: convert, length, endof, show, done, next, ndims, start, delete!, eltype, size, sizeof, unsafe_convert
 
 const magic_base = "Julia data file (HDF5), version "
 const version_current = v"0.1.1"


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/17057 doesn't support `@eval`, but I want to be able to run BaseBenchmarks on it. So this replaces all of the `@eval` functions with their roughly equivalent `@generated` functions.