### PR TITLE
eval julia_type input in Main instead of current_module()

### DIFF
--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -983,8 +983,14 @@ end
 
 @compat function julia_type(e::Union{Symbol, Expr})
     if is_valid_type_ex(e)
-        try     # try needed to catch undefined symbols
+        try # `try` needed to catch undefined symbols
             typ = eval(current_module(), e)
+            isa(typ, Type) && return typ
+        end
+        try
+            # It's possible that `e` will represent a type not present in current_module(),
+            # but as long as `e` is fully qualified, it should exist/be reachable from Main
+            typ = eval(Main, e)
             isa(typ, Type) && return typ
         end
     end


### PR DESCRIPTION
...since input types might not exist in `current_module()`. This fixes using a function which calls `JLD.translate` inside a module scope where `JLD` is not imported (but the caller does have `JLD` imported). This bug can be seen in the `SerializationTests` failure [here](https://github.com/JuliaCI/BenchmarkTools.jl/pull/23).

I'm not sure whether this PR is really the correct fix for this issue - it might violate existing assumptions or rely on bad assumptions. For example, this fix may be broken if `e` is not fully qualified.

Credit to @maleadt for hunting this down. 
