### PR TITLE
Test JLDArchives on appveyor too

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
   - C:\projects\julia\bin\julia -F -e "versioninfo();
-      Pkg.clone(pwd(), \"JLD\"); Pkg.build(\"JLD\")"
+      Pkg.clone(pwd(), \"JLD\"); Pkg.build(\"JLD\"); Pkg.add(\"JLDArchives\"); Pkg.checkout(\"JLDArchives\")"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"JLD\")"
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"JLD\"); Pkg.test(\"JLDArchives\")"


### PR DESCRIPTION
Right now 0.6 master is segfaulting when testing JLDArchives. It's good to also catch these out so I added them to appveyor too.