### PR TITLE
Add support for StackFrames

### DIFF
--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -871,6 +871,29 @@ end
 readas(grs::GlobalRefSerializer) = GlobalRef(eval(modname2mod(grs.mod)), grs.name)
 writeas(gr::GlobalRef) = GlobalRefSerializer(gr)
 
+# StackFrame (Null the LambdaInfo in 0.5)
+if VERSION > v"0.5.0-dev+2420"
+    if VERSION < v"0.6.0-dev.615"
+        JLD.writeas(data::StackFrame) = Base.StackFrame(
+                   data.func,
+                   data.file,
+                   data.line,
+                   Nullable{Core.LambdaInfo}(),
+                   data.from_c,
+                   data.inlined,
+                   data.pointer)
+    else # or Core.MethodInstance in 0.6
+        JLD.writeas(data::StackFrame) = Base.StackFrame(
+                   data.func,
+                   data.file,
+                   data.line,
+                   Nullable{Core.MethodInstance}(),
+                   data.from_c,
+                   data.inlined,
+                   data.pointer)
+    end
+end
+
 ### Converting attribute strings to Julia types
 
 const _where_macrocall = Symbol("@where")

--- a/test/jldtests.jl
+++ b/test/jldtests.jl
@@ -958,5 +958,7 @@ f2()
 li, lidict = Profile.retrieve()
 f = tempname()*".jld"
 @save f li lidict
-@test isa(JLD.load(f)["lidict"], Dict{UInt64,Array{StackFrame,1}})
+if VERSION > v"0.5.0-dev+2420" # when StackFrames were introduced
+    @test isa(JLD.load(f)["lidict"], Dict{UInt64,Array{StackFrame,1}})
+end
 rm(f)

--- a/test/jldtests.jl
+++ b/test/jldtests.jl
@@ -952,3 +952,11 @@ f2()
 @test (@eval @load $fn) == [:loadmacrotestvar1, :loadmacrotestvar2]
 @test loadmacrotestvar1 == ['a', 'b', 'c']
 @test loadmacrotestvar2 == 1
+
+# Test StackFrame by saving profile output
+@profile eigvals(randn(3,3))
+li, lidict = Profile.retrieve()
+f = tempname()*".jld"
+@save f li lidict
+@test isa(JLD.load(f)["lidict"], Dict{UInt64,Array{StackFrame,1}})
+rm(f)

--- a/test/jldtests.jl
+++ b/test/jldtests.jl
@@ -355,7 +355,7 @@ fn = joinpath(tempdir(),"test.jld")
 # Issue #106
 module Mod106
 bitstype 64 Typ{T}
-typ{T}(x::Int64, ::Type{T}) = Base.box(Typ{T}, Base.unbox(Int64,x))
+typ{T}(x::Int64, ::Type{T}) = reinterpret(Typ{T}, x)
 abstract UnexportedT
 end
 


### PR DESCRIPTION
by nulling the `MethodInstance`/`LambdaInfo` field. This is useful for storing profile output.