### PR TITLE
Make `T{typeof(f)}()` `load`able again

### DIFF
--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -991,10 +991,11 @@ end
 function _julia_type(s::AbstractString)
     typ = get(_typedict, s, UnconvertedType)
     if typ == UnconvertedType
-        sp = parse(s, raise=false)
-        if (isa(sp, Expr) && (sp.head == :error || sp.head == :continue || sp.head == :incomplete))
+        sp = try
+            parse(s)
+        catch err
             println("error parsing type string ", s)
-            eval(sp)
+            rethrow(err)
         end
         typ = julia_type(fixtypes(sp))
         if typ != UnsupportedType

--- a/test/jldtests.jl
+++ b/test/jldtests.jl
@@ -953,6 +953,14 @@ f2()
 @test loadmacrotestvar1 == ['a', 'b', 'c']
 @test loadmacrotestvar2 == 1
 
+mktempdir() do dir
+    cd(dir) do
+        JLD.save("_.jld", "_", Val{typeof(sin)}())
+        # should not throw an error
+        JLD.load("_.jld", "_")
+    end
+end
+
 # Test StackFrame by saving profile output
 @profile eigvals(randn(3,3))
 li, lidict = Profile.retrieve()


### PR DESCRIPTION
This patch fixes a regression introduced by 94af823c621a9e5cb5fcd8af1c364a2f3197ce22.
Now the return value of `Optim.optimize` is `load`able again.