### PR TITLE
Memory Map link to hdf5 package

### DIFF
--- a/doc/jld.md
+++ b/doc/jld.md
@@ -42,7 +42,7 @@ by other applications unless a Blosc plugin is installed.
 If you also specify `compatible=true`, then a different (and often slower)
 compression method is used that should be readabye by any HDF5-using software.
 
-JLD files can be opened with the `mmaparrays` option, which if true returns "qualified" array data sets as arrays using [memory-mapping](hdf5.md#memory-mapping):
+JLD files can be opened with the `mmaparrays` option, which if true returns "qualified" array data sets as arrays using [memory-mapping](https://github.com/JuliaIO/HDF5.jl/blob/master/doc/hdf5.md#memory-mapping):
 
 ```julia
 file = jldopen("mydata.jld", "r", mmaparrays=true)


### PR DESCRIPTION
hdf5.md no longer in this repo. See commit: https://github.com/JuliaIO/JLD.jl/commit/faf41bfc96bc3ba0acaad0fde79ea3dca9b6c677