### PR TITLE
replace Core.BottomType => typeof(Union{})

### DIFF
--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -1036,7 +1036,7 @@ function full_typename(io::IO, file::JldFile, jltype::Union)
     print(io, ')')
 end
 if TYPESYSTEM_06
-function full_typename(io::IO, file::JldFile, x::Core.BottomType)
+function full_typename(io::IO, file::JldFile, x::typeof(Union{}))
     print(io, "Union()")
 end
 function full_typename(io::IO, file::JldFile, x::UnionAll)


### PR DESCRIPTION
This change should be merged and tagged in a release before
https://github.com/JuliaLang/julia/pull/21057 renames Core.BottomType