### PR TITLE
Adjust test of StackFrame serialization to work on 32 bit platforms

### DIFF
--- a/test/jldtests.jl
+++ b/test/jldtests.jl
@@ -961,6 +961,6 @@ li, lidict = Profile.retrieve()
 f = tempname()*".jld"
 @save f li lidict
 if VERSION > v"0.5.0-dev+2420" # when StackFrames were introduced
-    @test isa(JLD.load(f)["lidict"], Dict{UInt64,Array{StackFrame,1}})
+    @test isa(JLD.load(f)["lidict"], Dict{UInt,Array{StackFrame,1}})
 end
 rm(f)


### PR DESCRIPTION
I don't have a 32 bit installation so I'm now sure if this works. Let's see what AppVeyor says.