### PR TITLE
fix missing gc-roots

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (c) 2012-2013 Timothy E. Holy, Konrad Hinsen, Tom Short, and Simon Kornblith
+Copyright (c) 2012-2017 Timothy E. Holy, Konrad Hinsen, Tom Short, Simon Kornblith, Google Inc., and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
 HDF5
-Compat 0.18.0
+Compat 0.25.0
 FileIO
 LegacyStrings

--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -879,7 +879,7 @@ JLD.writeas(data::StackFrame) =
 const _where_macrocall = Symbol("@where")
 function expand_where_macro(e::Expr)
     e.head = :where
-    shift!(e.args)
+    Compat.macros_have_sourceloc && shift!(e.args)
     return true
 end
 

--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -875,6 +875,7 @@ JLD.writeas(data::StackFrame) =
 const _where_macrocall = Symbol("@where")
 function expand_where_macro(e::Expr)
     e.head = :where
+    shift!(e.args)
     Compat.macros_have_sourceloc && shift!(e.args)
     return true
 end
@@ -946,11 +947,9 @@ function fixtypes(typ::Expr, whereall::Vector{Any})
 
     if (typ.head === :call && !isempty(typ.args) &&
         typ.args[1] === :TypeVar) # TypeVar => where format backwards compatibility
-        if TYPESYSTEM_06
-            tv = gensym()
-            push!(whereall, Expr(:(=), tv, typ))
-            return tv
-        end
+        tv = gensym()
+        push!(whereall, Expr(:(=), tv, typ))
+        return tv
     end
 
     if (typ.head === :call && !isempty(typ.args) &&

--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -200,9 +200,6 @@ function jldopen(filename::AbstractString, rd::Bool, wr::Bool, cr::Bool, tr::Boo
                 version = convert(VersionNumber, unsafe_string(pointer(magic) + length(magic_base)))
                 gcuse(magic)
                 if version < v"0.1.0"
-                    if !isdefined(JLD, :JLD00)
-                        eval(:(include(joinpath($(dirname(@__FILE__)), "JLD00.jl"))))
-                    end
                     fj = JLD00.jldopen(filename, rd, wr, cr, tr, ff; mmaparrays=mmaparrays)
                 else
                     f = HDF5.h5f_open(filename, wr ? HDF5.H5F_ACC_RDWR : HDF5.H5F_ACC_RDONLY, pa.id)
@@ -1282,4 +1279,5 @@ function __init__()
     nothing
 end
 
+include("JLD00.jl")
 end

--- a/src/JLD00.jl
+++ b/src/JLD00.jl
@@ -434,9 +434,7 @@ function read(obj::JldDataset, ::Type{Expr})
 end
 
 # CompositeKind
-if JLD.TYPESYSTEM_06
-    read(obj::JldDataset, T::UnionAll) = read(obj, Base.unwrap_unionall(T))
-end
+read(obj::JldDataset, T::UnionAll) = read(obj, Base.unwrap_unionall(T))
 function read(obj::JldDataset, T::DataType)
     if isempty(fieldnames(T)) && T.size > 0
         return read_bitstype(obj, T)
@@ -450,9 +448,7 @@ function read(obj::JldDataset, T::DataType)
             for i = 1:length(params)
                 p[i] = eval(current_module(), parse(params[i]))
             end
-            if JLD.TYPESYSTEM_06
-                T = T.name.wrapper
-            end
+            T = T.name.wrapper
             T = T{p...}
         end
     end

--- a/src/JLD00.jl
+++ b/src/JLD00.jl
@@ -8,7 +8,7 @@ using HDF5, Compat, LegacyStrings
 import HDF5: close, dump, exists, file, getindex, setindex!, g_create, g_open, o_delete, name, names, read, size, write,
              HDF5ReferenceObj, HDF5BitsKind, ismmappable, readmmap
 import Base: length, endof, show, done, next, start, delete!
-import JLD
+import ..JLD
 
 # See julia issue #8907
 replacements = Any[]
@@ -431,6 +431,9 @@ function read(obj::JldDataset, ::Type{Expr})
 end
 
 # CompositeKind
+if JLD.TYPESYSTEM_06
+    read(obj::JldDataset, T::UnionAll) = read(obj, T.body)
+end
 function read(obj::JldDataset, T::DataType)
     if isempty(fieldnames(T)) && T.size > 0
         return read_bitstype(obj, T)
@@ -442,6 +445,9 @@ function read(obj::JldDataset, T::DataType)
         p = Vector{Any}(length(params))
         for i = 1:length(params)
             p[i] = eval(current_module(), parse(params[i]))
+        end
+        if JLD.TYPESYSTEM_06
+            T = T.name.wrapper
         end
         T = T{p...}
     end

--- a/src/jld_types.jl
+++ b/src/jld_types.jl
@@ -150,7 +150,8 @@ function h5type(::JldFile, ::Type{T}, ::Bool) where T<:String
     JldDatatype(HDF5Datatype(type_id, false), 0)
 end
 
-h5convert!(out::Ptr, ::JldFile, x::String, ::JldWriteSession) =
+# no-inline needed to ensure gc-root for x
+@noinline h5convert!(out::Ptr, ::JldFile, x::String, ::JldWriteSession) =
     unsafe_store!(convert(Ptr{Ptr{UInt8}}, out), pointer(x))
 
 if !(isdefined(Core, :String) && isdefined(Core, :AbstractString))
@@ -184,7 +185,8 @@ function h5type(parent::JldFile, ::Type{UTF16String}, commit::Bool)
     commit ? commit_datatype(parent, dtype, UTF16String) : JldDatatype(dtype, -1)
 end
 
-h5convert!(out::Ptr, ::JldFile, x::UTF16String, ::JldWriteSession) =
+# no-inline needed to ensure gc-root for x
+@noinline h5convert!(out::Ptr, ::JldFile, x::UTF16String, ::JldWriteSession) =
     unsafe_store!(convert(Ptr{HDF5.Hvl_t}, out), HDF5.Hvl_t(length(x.data), pointer(x.data)))
 
 function jlconvert(::Type{UTF16String}, ::JldFile, ptr::Ptr)

--- a/test/jldtests.jl
+++ b/test/jldtests.jl
@@ -791,7 +791,7 @@ end # compress in (false,true)
 module JLDTemp1
 using Compat: @compat
 using JLD
-import ..fn, Core.Intrinsics.box
+import ..fn
 
 mutable struct TestType1
     x::Int
@@ -846,7 +846,6 @@ struct TestType3
     x::TestType1
 end
 
-import Core.Intrinsics.box, Core.Intrinsics.unbox
 jldopen(fn, "r") do file
     @test_throws JLD.TypeMismatchException read(file, "x1")
     @test_throws MethodError read(file, "x2")

--- a/test/type_translation.jl
+++ b/test/type_translation.jl
@@ -33,10 +33,9 @@ mutable struct MyOldType
     a::Int
 end
 
-translate("MyType", "MyOldType")
+translate("MyType", "Translation.Reading.MyOldType")
 
 t = jldopen(filename) do file
-    truncate_module_path(file, Reading)
     read(file, "x")
 end
 


### PR DESCRIPTION
since calling `pointer()` explicitly discards gc-rooting
need to ensure that there is a memory barrier that uses the value
after we know for certain we are done with the value
