### PR TITLE
Fix typeassert error in read_refs

### DIFF
--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -494,7 +494,7 @@ function read_refs{T}(obj::JldDataset, ::Type{T}, dspace_id::HDF5.Hid, dsel_id::
             end
             return out
         else
-            throw(e)
+            rethrow(e)
         end
     end
 end

--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -475,14 +475,28 @@ function read_refs{T}(obj::JldDataset, ::Type{T}, dspace_id::HDF5.Hid, dsel_id::
     refs = Array{HDF5ReferenceObj}(dims)
     HDF5.h5d_read(obj.plain.id, HDF5.H5T_STD_REF_OBJ, dspace_id, dsel_id, HDF5.H5P_DEFAULT, refs)
 
-    out = Array{Any}(dims)
     f = file(obj)
-    for i = 1:length(refs)
-        if refs[i] != HDF5.HDF5ReferenceObj_NULL
-            out[i] = read_ref(f, refs[i])
+    try
+        out = Array{T}(dims)
+        for i = 1:length(refs)
+            if refs[i] != HDF5.HDF5ReferenceObj_NULL
+                out[i] = read_ref(f, refs[i])
+            end
+        end
+        return out
+    catch e
+        if isa(e, TypeError)
+            out = Array{Any}(dims)
+            for i = 1:length(refs)
+                if refs[i] != HDF5.HDF5ReferenceObj_NULL
+                    out[i] = read_ref(f, refs[i])
+                end
+            end
+            return out
+        else
+            throw(e)
         end
     end
-    out
 end
 
 # Get element type of a reference array

--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -475,7 +475,7 @@ function read_refs{T}(obj::JldDataset, ::Type{T}, dspace_id::HDF5.Hid, dsel_id::
     refs = Array{HDF5ReferenceObj}(dims)
     HDF5.h5d_read(obj.plain.id, HDF5.H5T_STD_REF_OBJ, dspace_id, dsel_id, HDF5.H5P_DEFAULT, refs)
 
-    out = Array{T}(dims)
+    out = Array{Any}(dims)
     f = file(obj)
     for i = 1:length(refs)
         if refs[i] != HDF5.HDF5ReferenceObj_NULL


### PR DESCRIPTION
This patch fixes a typeassert error that arises in the read_refs function in [src/JLD.jl:482](https://github.com/JuliaIO/JLD.jl/blob/master/src/JLD.jl#L482). The error arises when, for example, `eltype(out)` is `Array{Array,1}` but `typeof(read_ref(f, refs[i]))` is `Array{Array{Float32,1},1}`. `Array{Float32,1}` is a subtype of `Array`, but `Array{Array{Float32,1},1}` is not a subtype of `Array{Array,1}` because in Julia [type parameters are invariant](https://docs.julialang.org/en/stable/manual/types/#Parametric-Composite-Types-1).
```
julia> Array{Float32,1} <: Array
true
julia> Array{Array{Float32,1}, 1} <: Array{Array, 1}
false
```
Thus, if you try to assign a value of type `Array{Array{Float32,1},1}` to `out[i]`, but `out[i] `is expecting a value of type` Array{Array,1}`, then a TypeAssert is thrown.

The simple workaround is to change the type of `out` from `Array{T}` to `Array{Any}`.

Fixes #154 in this repo as well as pluskid/Mocha.jl#219 and pluskid/Mocha.jl#229. (All are the same issue.)