### PR TITLE
Fix for packages not loaded into Main on 0.7

### DIFF
--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -1246,8 +1246,17 @@ function FileIO.load(f::File{format"JLD"}, varnames::Tuple{Vararg{AbstractString
     end
 end
 
+# As of this version, packages aren't loaded into Main by default, so the root
+# module check verifies that packages are still identified as being top level
+# even if a binding to them is not present in Main.
+if VERSION >= v"0.7.0-DEV.1877"
+    _istoplevel(m::Module) = module_parent(m) == Main || Base.is_root_module(m)
+else
+    _istoplevel(m::Module) = module_parent(m) == Main
+end
+
 function addrequire(file::JldFile, mod::Module)
-    module_parent(mod) == Main || error("must be a toplevel module")
+    _istoplevel(mod) || error("must be a toplevel module")
     addrequire(file, module_name(mod))
 end
 


### PR DESCRIPTION
As of https://github.com/JuliaLang/julia/pull/23579, packages aren't loaded into Main by default, which breaks one of the checks we're using here in `addrequire`. This PR fixes that by adding an additional check for whether the given module is a root module.

See also discussion in https://github.com/JuliaLang/julia/commit/ff9fb483172ad792c47b7652eff1173044f3b9ae, and cc @KristofferC.