### PR TITLE
refactor: simplify map call

### DIFF
--- a/src/JLD00.jl
+++ b/src/JLD00.jl
@@ -400,7 +400,7 @@ read(obj::JldDataset, ::Type{Array{Symbol,N}}) where {N} = map(Symbol, read(obj.
 read(obj::JldDataset, ::Type{Char}) = Char(read(obj.plain, UInt32))
 
 read(obj::JldDataset, ::Type{UTF16String}) = UTF16String(read(obj.plain, Array{UInt16}))
-read(obj::JldDataset, ::Type{Array{UTF16String,N}}) where {N} = map(x->UTF16String(x), read(obj, Array{Vector{UInt16},N}))
+read(obj::JldDataset, ::Type{Array{UTF16String,N}}) where {N} = map(UTF16String, read(obj, Array{Vector{UInt16},N}))
 
 # General arrays
 read(obj::JldDataset, t::Type{Array{T,N}}) where {T,N} = getrefs(obj, T)


### PR DESCRIPTION
A simple refactor based on the [style guide](https://docs.julialang.org/en/v1/manual/style-guide/#Do-not-write-x-f(x)-1).