### PR TITLE
Update before_script in OSX travis to forcibly link gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ addons:
   apt:
     packages:
     - hdf5-tools
+before_script:
+    - if [ $TRAVIS_OS_NAME = osx ]; then brew install gcc; brew link --overwrite gcc; brew install hdf5; fi
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.develop("JLDArchives")'


### PR DESCRIPTION
try to fix osx travis