### PR TITLE
allow saving Ptrs

### DIFF
--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -1126,9 +1126,6 @@ function save_write(f, s, vname, wsession::JldWriteSession)
         try
             write(f, s, vname)
         catch e
-            if isa(e, PointerException)
-                @warn("Skipping $vname because it contains a pointer")
-            end
         end
     end
 end

--- a/src/jld_types.jl
+++ b/src/jld_types.jl
@@ -273,10 +273,6 @@ end
 jlconvert(::Type{T}, file::JldFile, ptr::Ptr) where {T<:Type} =
     julia_type(jlconvert(String, file, ptr))
 
-## Pointers
-
-h5type(parent::JldFile, ::Type{T}, ::Bool) where {T<:Ptr} = throw(PointerException())
-
 ## Union{}
 
 h5fieldtype(parent::JldFile, ::Type{Union{}}, ::Bool) = JLD_REF_TYPE

--- a/test/jldtests.jl
+++ b/test/jldtests.jl
@@ -460,7 +460,7 @@ for compatible in (false, true), compress in (false, true)
     @write fid undefv
     @write fid undefm
     @write fid ms_undef
-    @test_throws JLD.PointerException @write fid objwithpointer
+    @write fid objwithpointer
     @write fid bt
     @write fid sa_asc
     @write fid sa_utf8


### PR DESCRIPTION
I believe disallowing saving Ptrs does more harm than good. If you're saving a bunch of values and one of them happens to have a pointer somewhere, the whole thing blows up. This could happen, for example, when saving the state of a program for postmortem analysis. Might as well just save everything and let the chips fall where they may.