### PR TITLE
Fix to allow reading booleans from the file.

### DIFF
--- a/src/jld_types.jl
+++ b/src/jld_types.jl
@@ -703,6 +703,8 @@ function jldatatype(parent::JldFile, dtype::HDF5Datatype)
         HDF5.h5t_equal(dtype.id, HDF5.H5T_NATIVE_UINT16) > 0 && return UInt16
         HDF5.h5t_equal(dtype.id, HDF5.H5T_NATIVE_B8) > 0 && return Bool
         error("unrecognized integer or float type")
+    elseif class_id == HDF5.H5T_BITFIELD
+        Bool
     elseif class_id == HDF5.H5T_COMPOUND || class_id == HDF5.H5T_OPAQUE
         addr = HDF5.objinfo(dtype).addr
         haskey(parent.h5jltype, addr) && return parent.h5jltype[addr]

--- a/test/jldtests.jl
+++ b/test/jldtests.jl
@@ -2,6 +2,7 @@ using HDF5, JLD
 using Compat, LegacyStrings
 using Compat.Test, Compat.LinearAlgebra
 using Compat: @warn
+using Random
 
 @static if VERSION ≥ v"0.7.0-DEV.2329"
     using Profile
@@ -982,4 +983,23 @@ mktempdir() do d
     @test isempty(t.tags) && eltype(t.tags) == Any
     @test isempty(t.data) && eltype(t.data) == Pair{Any,Any}
     rm(file)
+end
+
+# Issues #249 and #251
+let fid = jldopen(fn "w", mmaparrays = true)
+    write(fid, "a", true)
+    @test read(fid, "a") == true
+
+    write(fid, "b", false)
+    @test read(fid, "b") == false
+
+    write(fid, "c", Bool[true, true, false, false, true])
+    @test read(fid, "c") == Bool[true, true, false, false, true]
+
+    local t = Dict{String, Any}("a" => true, "b" => false, "c" => "xyz", "d" => 13)
+    write(fid, "d", t)
+    @test read(fid, "d") == t
+
+    close(fid)
+    rm(fn)
 end


### PR DESCRIPTION
This fixes Issue #249 and #251.  Basically it was just updating the jldatatype function to identify HDF5.H5T_BITFIELD as a Bool.

I added tests to the end of jldtests but I had trouble running that file on Julia 1.2.  I added "using Random" because the first error was randstring() was not found.  However I still could not run that file entirely. Not sure if I should have checked that in.  However the new tests do work if run by themselves. 