### PR TITLE
Ditch Compat, LegacyStrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.mat
 *.jl.*.cov
 *.jl.mem
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
     - osx
 julia:
     - 1.0
-    - 1.3
+    - 1
     - nightly
 notifications:
     email: false
@@ -17,7 +17,7 @@ addons:
     - hdf5
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/JuliaIO/JLDArchives.jl.git"))'
-    - julia -e 'using Pkg; Pkg.test("JLD",coverage=true); Pkg.test("JLDArchives",coverage=true)'
+    - julia -e 'using Pkg; Pkg.GitTools.clone(Pkg.Types.Context(), "https://github.com/JuliaIO/JLDArchives.jl.git", "JLDArchives")'
+    - julia -e 'using Pkg; Pkg.test("JLD",coverage=true); include(joinpath("JLDArchives", "test", "runtests.jl"))'
 after_success:
     - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'using Pkg; cd(Pkg.dir("JLD")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ addons:
     - hdf5
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'using Pkg; Pkg.GitTools.clone(Pkg.Types.Context(), "https://github.com/JuliaIO/JLDArchives.jl.git", "JLDArchives")'
-    - julia -e 'using Pkg; Pkg.test("JLD",coverage=true); println(pwd()); @show(readdir("."), ispath("JLDArchives")); include(joinpath("JLDArchives", "test", "runtests.jl"))'
+    - julia -e 'using Pkg; Pkg.test("JLD", coverage=true)'
+    - if [ $TRAVIS_JULIA_VERSION != "1.0" ]; then julia --code-coverage=user -e 'using Pkg;
+          Pkg.GitTools.clone(Pkg.Types.Context(), "https://github.com/JuliaIO/JLDArchives.jl.git", "JLDArchives");
+          include(joinpath("JLDArchives", "test", "runtests.jl"))'; fi
 after_success:
     - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'using Pkg; cd(Pkg.dir("JLD")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ addons:
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'using Pkg; Pkg.GitTools.clone(Pkg.Types.Context(), "https://github.com/JuliaIO/JLDArchives.jl.git", "JLDArchives")'
-    - julia -e 'using Pkg; Pkg.test("JLD",coverage=true); include(joinpath("JLDArchives", "test", "runtests.jl"))'
+    - julia -e 'using Pkg; Pkg.test("JLD",coverage=true); println(pwd()); @show(readdir("."), ispath("JLDArchives")); include(joinpath("JLDArchives", "test", "runtests.jl"))'
 after_success:
     - if [ $TRAVIS_JULIA_VERSION = "nightly" ]; then julia -e 'using Pkg; cd(Pkg.dir("JLD")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'; fi

--- a/Project.toml
+++ b/Project.toml
@@ -1,20 +1,21 @@
 name = "JLD"
 uuid = "4138dd39-2aa7-5051-a626-17a0bb65d9c8"
-version = "0.9.2"
+version = "0.10.0"
 
 [deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
-LegacyStrings = "1b4a561d-cfcb-5daf-8433-43fcf8b4bea3"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-julia = "0.7, 1"
+julia = "1"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DataFrames", "Random", "Profile"]
+test = ["DataFrames", "LinearAlgebra", "Random", "Profile", "Test"]

--- a/src/jld_types.jl
+++ b/src/jld_types.jl
@@ -6,7 +6,7 @@ const INLINE_TUPLE = false
 const INLINE_POINTER_IMMUTABLE = false
 
 const JLD_REF_TYPE = JldDatatype(HDF5Datatype(HDF5.H5T_STD_REF_OBJ, false), 0)
-const BUILTIN_TYPES = Set([Symbol, Type, UTF16String, BigFloat, BigInt])
+const BUILTIN_TYPES = Set([Symbol, Type, BigFloat, BigInt])
 const JL_TYPENAME_TRANSLATE = Dict{String, String}()
 const JLCONVERT_INFO = Dict{Any, Any}()
 const H5CONVERT_INFO = Dict{Any, Any}()
@@ -170,31 +170,6 @@ function jlconvert(T::Union{Type{String}}, ::JldFile, ptr::Ptr)
     str = unsafe_string(strptr)
     Libc.free(strptr)
     str
-end
-
-## UTF16Strings
-
-h5fieldtype(parent::JldFile, ::Type{UTF16String}, commit::Bool) =
-    h5type(parent, UTF16String, commit)
-
-# Stored as compound types that contain a vlen
-function h5type(parent::JldFile, ::Type{UTF16String}, commit::Bool)
-    haskey(parent.jlh5type, UTF16String) && return parent.jlh5type[UTF16String]
-    vlen = HDF5.h5t_vlen_create(HDF5.H5T_NATIVE_UINT16)
-    id = HDF5.h5t_create(HDF5.H5T_COMPOUND, HDF5.h5t_get_size(vlen))
-    HDF5.h5t_insert(id, "data_", 0, vlen)
-    HDF5.h5t_close(vlen)
-    dtype = HDF5Datatype(id, parent.plain)
-    commit ? commit_datatype(parent, dtype, UTF16String) : JldDatatype(dtype, -1)
-end
-
-# no-inline needed to ensure gc-root for x
-@noinline h5convert!(out::Ptr, ::JldFile, x::UTF16String, ::JldWriteSession) =
-    unsafe_store!(convert(Ptr{HDF5.Hvl_t}, out), HDF5.Hvl_t(length(x.data), pointer(x.data)))
-
-function jlconvert(::Type{UTF16String}, ::JldFile, ptr::Ptr)
-    hvl = unsafe_load(convert(Ptr{HDF5.Hvl_t}, ptr))
-    UTF16String(unsafe_wrap(Array, convert(Ptr{UInt16}, hvl.p), hvl.len, own=true))
 end
 
 ## Symbols
@@ -599,7 +574,7 @@ unknown_type_err(T) =
     error("""$T is not of a type supported by JLD
              Please report this error at https://github.com/JuliaIO/HDF5.jl""")
 
-const BUILTIN_H5_types = Union{Nothing, Type, String, HDF5.HDF5BitsKind, UTF16String, Symbol, BigInt, BigFloat}
+const BUILTIN_H5_types = Union{Nothing, Type, String, HDF5.HDF5BitsKind, Symbol, BigInt, BigFloat}
 function gen_h5convert(parent::JldFile, @nospecialize(T))
     T <: BUILTIN_H5_types && return
     # TODO: this is probably invalid, so try to do this differently

--- a/test/custom_serialization.jl
+++ b/test/custom_serialization.jl
@@ -32,7 +32,6 @@ end # MyTypes
 module MySerializer
 
 using HDF5, JLD, ..MyTypes
-using Compat
 
 ## Defining the serialization format
 mutable struct MyContainerSerializer{T}
@@ -57,7 +56,7 @@ end
 
 end # MySerializer
 
-using ..MyTypes, JLD, Compat.Test
+using ..MyTypes, JLD, Test
 
 obj1 = MyType(rand(5), 2)
 obj2 = MyType(rand(5), 17)

--- a/test/jld_dataframe.jl
+++ b/test/jld_dataframe.jl
@@ -17,7 +17,7 @@ x = read(file, "df")
 y = read(file, "df2")
 close(file)
 
-using Compat.Test
+using Test
 @test isequal(df, x)
 @test isequal(df2, y)
 

--- a/test/require.jl
+++ b/test/require.jl
@@ -1,5 +1,5 @@
 using HDF5, JLD
-using Compat.Test
+using Test
 
 module JLDTemp
 using HDF5, JLD

--- a/test/type_translation.jl
+++ b/test/type_translation.jl
@@ -23,7 +23,7 @@ end # Writing
 
 module Reading
 
-using JLD, Compat.Test
+using JLD, Test
 import ..Translation: filename
 
 mutable struct MyType


### PR DESCRIPTION
LegacyStrings has never been released with a Project.toml. This removes it from the package, but with a cost: no support for UTF-16 strings. The fact that LegacyStrings has never been updated might be a sign that it is not in high demand.

This also removes the dependency on Compat, and modernizes some elements of the package.