### PR TITLE
Use ismutabletype(T) for datatypes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "4138dd39-2aa7-5051-a626-17a0bb65d9c8"
 version = "0.12.3"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -10,6 +11,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 [compat]
 FileIO = "1"
 HDF5 = "0.14, 0.15, 0.16"
+Compat = "3.40"
 julia = "1.3"
 
 [extras]

--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -1,19 +1,13 @@
 module JLD
 using Printf
 using HDF5, FileIO
+using Compat
 
 import HDF5: file, create_group, open_group, delete_object, name, ismmappable, readmmap
 import Base: close, convert, datatype_pointerfree, delete!, dump, eltype, getindex, iterate,
              length, ndims, read, setindex!, show, size, sizeof, unsafe_convert, write
 
 @noinline gcuse(x) = x # because of use of `pointer`, need to mark gc-use end explicitly
-
-@static if VERSION < v"1.7"
-    ismutabletype(::Type{T}) where T = T.mutable
-end
-@static if VERSION < v"1.5"
-    ismutable(x) = ismutabletype(typeof(x))
-end
 
 const magic_base = "Julia data file (HDF5), version "
 const version_current = v"0.1.3"

--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -11,6 +11,9 @@ import Base: close, convert, datatype_pointerfree, delete!, dump, eltype, getind
 @static if VERSION < v"1.7"
     ismutabletype(::Type{T}) where T = T.mutable
 end
+@static if VERSION < v"1.5"
+    ismutable(x) = ismutabletype(typeof(x))
+end
 
 const magic_base = "Julia data file (HDF5), version "
 const version_current = v"0.1.3"

--- a/src/JLD00.jl
+++ b/src/JLD00.jl
@@ -472,7 +472,7 @@ function read(obj::JldDataset, T::DataType)
         if length(v) != length(n)
             error("Wrong number of fields")
         end
-        if !T.mutable
+        if !ismutabletype(T)
             x = ccall(:jl_new_structv, Any, (Any,Ptr{Cvoid},UInt32), T, v, length(fieldnames(T)))
         else
             x = ccall(:jl_new_struct_uninit, Any, (Any,), T)

--- a/src/JLD00.jl
+++ b/src/JLD00.jl
@@ -10,6 +10,10 @@ import HDF5: file, create_group, open_group, delete_object, name, ismmappable, r
 import Base: close, dump, getindex, iterate, length, read, setindex!, size, show, delete!, write
 import ..JLD: JLD, _joinpath
 
+@static if VERSION < v"1.7"
+    import ..JLD: ismutabletype
+end
+
 # See julia issue #8907
 replacements = Any[]
 push!(replacements, :(s = replace(s, r"Uint(?=\d{1,3})" => "UInt")))

--- a/src/JLD00.jl
+++ b/src/JLD00.jl
@@ -5,14 +5,11 @@
 module JLD00
 using Printf
 using HDF5
+using Compat
 # Add methods to...
 import HDF5: file, create_group, open_group, delete_object, name, ismmappable, readmmap
 import Base: close, dump, getindex, iterate, length, read, setindex!, size, show, delete!, write
 import ..JLD: JLD, _joinpath
-
-@static if VERSION < v"1.7"
-    import ..JLD: ismutabletype
-end
 
 # See julia issue #8907
 replacements = Any[]

--- a/src/jld_types.jl
+++ b/src/jld_types.jl
@@ -308,10 +308,10 @@ end
 # this is a reference. If the type is immutable, this is a type itself.
 if INLINE_POINTER_IMMUTABLE
     h5fieldtype(parent::JldFile, @nospecialize(T), commit::Bool) =
-        isconcretetype(T) && (!T.mutable || T.size == 0) ? h5type(parent, T, commit) : JLD_REF_TYPE
+        isconcretetype(T) && (!ismutabletype(T) || T.size == 0) ? h5type(parent, T, commit) : JLD_REF_TYPE
 else
     h5fieldtype(parent::JldFile, @nospecialize(T), commit::Bool) =
-        isconcretetype(T) && (!T.mutable || T.size == 0) && datatype_pointerfree(T) ? h5type(parent, T, commit) : JLD_REF_TYPE
+        isconcretetype(T) && (!ismutabletype(T) || T.size == 0) && datatype_pointerfree(T) ? h5type(parent, T, commit) : JLD_REF_TYPE
 end
 
 function h5type(parent::JldFile, T::Type{Bool}, commit::Bool)
@@ -506,14 +506,14 @@ function gen_jlconvert(@nospecialize(T))
     if isa(T, TupleType)
         return _gen_jlconvert_tuple(typeinfo, T)
     elseif isempty(fieldnames(T))
-        if T.size == 0 && !T.mutable
+        if T.size == 0 && !ismutabletype(T)
             return T.instance
         else
            return :(_jlconvert_bits(T, ptr))
         end
     elseif T.size == 0
         return :(ccall(:jl_new_struct_uninit, Ref{T}, (Any,), T))
-    elseif T.mutable
+    elseif ismutabletype(T)
         return _gen_jlconvert_type(typeinfo, T)
     else
         return _gen_jlconvert_immutable(typeinfo, T)
@@ -526,7 +526,7 @@ function gen_jlconvert!(@nospecialize(T))
         error("unimplemented")
     elseif isempty(fieldnames(T))
         if T.size == 0
-            if !T.mutable
+            if !ismutabletype(T)
                 return nothing
             else
                 return :(unsafe_store!(convert(Ptr{Any}, out), $(T.instance)); nothing)
@@ -536,7 +536,7 @@ function gen_jlconvert!(@nospecialize(T))
         end
     elseif T.size == 0
         return nothing
-    elseif T.mutable
+    elseif ismutabletype(T)
         return _gen_jlconvert_type!(typeinfo, T)
     else
         return _gen_jlconvert_immutable!(typeinfo, T)


### PR DESCRIPTION
`T.mutable` no longer exists of https://github.com/JuliaLang/julia/pull/41018 (Julia 1.7)

Use new `ismutabletype` instead. Create a backwards compatible shim for Julia < 1.7 for `ismutabletype`.