### PR TITLE
Add `compress=true/false` option to `@save` macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD"
 uuid = "4138dd39-2aa7-5051-a626-17a0bb65d9c8"
-version = "0.13.2"
+version = "0.13.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ advanced features, then a simple syntax is:
 t = 15
 z = [1,3]
 save("/tmp/myfile.jld", "t", t, "arr", z)
+# or equivalently:
+@save "/tmp/myfile.jld" t z
 ```
 Here we're explicitly saving `t` and `z` as `"t"` and `"arr"` within
 `myfile.jld`. You can alternatively pass `save` a dictionary; the keys must be
@@ -72,10 +74,16 @@ This problem is not encountered while loading a JLD file because FileIO can use
 magic bytes at the beginning of the file to infer its data format.
 
 There are also convenience macros `@save` and `@load` that work on the
-variables themselves. `@save "/tmp/myfile.jld" t z` will create a file with
-just `t` and `z`; if you don't mention any variables, then it saves all the
-variables in the current module. Conversely, `@load` will pop the saved
-variables directly into the global workspace of the current module.
+variables themselves.
+```julia
+@save "/tmp/myfile.jld" t z
+# or
+@save compress=true "/tmp/myfile.jld" t z
+```
+will create a file with just `t` and `z`, with or without compression.
+If you don't mention any variables, then `@save` saves all the variables in the
+current module. Conversely, `@load` will pop the saved variables directly into
+the global workspace of the current module.
 However, keep in mind that these macros have significant limitations: for example,
 you can't use `@load` inside a function, there are constraints on using string
 interpolation inside filenames, etc. These limitations stem

--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -1169,6 +1169,15 @@ function save_write(f, s, vname, wsession::JldWriteSession)
     end
 end
 
+"""
+```julia
+@save "filename.jld" var1 [var2 var3 ...]
+@save compress=true "filename.jld" var1 [var2 var3 ...]
+```
+Save the variables `var1` (and optionally `var2`, `var3`, etc.) to a JLD file "filename.jld".
+Optionally you may specify `compress=true` or `compress=false` as the first argument,
+to specify whether the resulting `.jld` file should be compressed (default=`false`).
+"""
 macro save(filename, vars...)
     if isempty(vars)
         # Save all variables in the current module
@@ -1235,6 +1244,19 @@ macro save(opt::Expr, filename, vars...)
     end
 end
 
+"""
+```julia
+@load "filename.jld"
+@load "filename.jld" var1 [var2 var3 ...]
+```
+Load the variables `var1`, `var2`, et cetera, contained in the file
+`filename.jld` into the current global scope.
+
+If no variable names are specified, all variables from the file will be loaded.
+
+Returns a `Vector` of `Symbol`s corresponding to the names of the loaded
+variables.
+"""
 macro load(filename, vars...)
     if isempty(vars)
         if isa(filename, Expr)

--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -1202,7 +1202,7 @@ macro save(filename, vars...)
 end
 
 macro save(opt::Expr, filename, vars...)
-    compress = opt.head === :(=) && first(opt.args) === :compress && last(opt.args) == true
+    compress = (opt.head === :(=) && first(opt.args) === :compress) ? last(opt.args) : false
 
     if isempty(vars)
         # Save all variables in the current module
@@ -1225,7 +1225,7 @@ macro save(opt::Expr, filename, vars...)
     end
 
     quote
-        local f = jldopen($(esc(filename)), "w", compress=$compress)
+        local f = jldopen($(esc(filename)), "w", compress=$(esc(compress)))
         wsession = JldWriteSession()
         try
             $(Expr(:block, writeexprs...))


### PR DESCRIPTION
This PR adds an optional first argument to the `@save` macro, where you can specify either `compress=true` or `compress=false`, which will be passed on to the underlying `jldopen ` call.

This PR also adds docstrings for `@load` and `@save`, which were previously missing, and adds a few more examples to the README.