### PR TITLE
Fix HDF5.exists, HDF5.haddr_t, and HDF5.object_info deprecation warnings

### DIFF
--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -1410,7 +1410,6 @@ include("JLD00.jl")
 ### v0.12.0 deprecations
 ###
 
-import HDF5: exists
 export exists
 @noinline function exists(p::Union{JldFile, JldGroup, JldDataset}, path::String)
     Base.depwarn("`exists(p, path)` is deprecated, use `haskey(p, path)` instead.", :exists)

--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -693,7 +693,7 @@ function write_ref(parent::JldFile, data, wsession::JldWriteSession)
     dset = _write(gref, name, writeas(data), wsession)
 
     # Add reference to reference list
-    ref = HDF5.Reference(HDF5.API.hobj_ref_t(object_info(dset).addr))
+    ref = HDF5.Reference(HDF5.API.hobj_ref_t(HDF5.API.h5o_get_info1(HDF5.checkvalid(dset)).addr))
     close(dset)
     if !isa(data, Tuple) && ismutable(data)
         wsession.h5ref[data] = ref

--- a/src/jld_types.jl
+++ b/src/jld_types.jl
@@ -687,7 +687,7 @@ function jldatatype(parent::JldFile, dtype::HDF5.Datatype)
     elseif class_id == HDF5.API.H5T_BITFIELD
         Bool
     elseif class_id == HDF5.API.H5T_COMPOUND || class_id == HDF5.API.H5T_OPAQUE
-        addr = object_info(dtype).addr
+        addr = HDF5.API.h5o_get_info1(HDF5.checkvalid(dtype)).addr
         haskey(parent.h5jltype, addr) && return parent.h5jltype[addr]
 
         typename = read_attribute(dtype, name_type_attr)
@@ -805,11 +805,11 @@ end
 # it's already many times faster than calling H5Iget_name with a lot of
 # data in the file, and it only needs to be called once per type.
 # Revisit if this ever turns out to be a bottleneck.
-function typeindex(parent::JldFile, addr::HDF5.haddr_t)
+function typeindex(parent::JldFile, addr::HDF5.API.haddr_t)
     gtypes = parent.plain[pathtypes]
     i = 1
     for x in gtypes
-        if object_info(x).addr == addr
+        if HDF5.API.h5o_get_info1(HDF5.checkvalid(x)).addr == addr
             return i
         end
         i += 1


### PR DESCRIPTION
HDF5.exists was removed in v0.16 of HDF5 and since the present version of JLD specifies this as minimum compatible HDF5 version, it is safe to remove the warning.

Also update HDF5.haddr_t and HDF5 deprecated calls


fix https://github.com/JuliaIO/JLD.jl/issues/323 https://github.com/JuliaIO/JLD.jl/issues/324