### PR TITLE
Fix use of HDF5._dataspace

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JLD"
 uuid = "4138dd39-2aa7-5051-a626-17a0bb65d9c8"
-version = "0.13.4"
+version = "0.13.5"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/JLD.jl
+++ b/src/JLD.jl
@@ -761,7 +761,7 @@ function getindex(dset::JldDataset, indices::Union{AbstractRange{Int},Integer}..
     sz = map(length, indices)
     dsel = HDF5.hyperslab(dset.plain, indices...)
     try
-        dspace = HDF5._dataspace(sz)
+        dspace = HDF5.dataspace(sz)
         try
             return read_array(dset, datatype(dset.plain), dspace.id, dsel.id, sz)
         finally
@@ -791,7 +791,7 @@ function setindex!(dset::JldDataset, X::AbstractArray{T,N}, indices::Union{Abstr
             buf = h5convert_array(f, convert(Array{written_eltype,N}, X), jldtype,
                                   JldWriteSession())
 
-            dspace = HDF5._dataspace(sz)
+            dspace = HDF5.dataspace(sz)
             try
                 HDF5.API.h5d_write(dset.plain.id, dtype, dspace, dsel_id, HDF5.API.H5P_DEFAULT, buf)
             finally


### PR DESCRIPTION
https://github.com/JuliaIO/HDF5.jl/pull/1104 removed HDF5._dataspace which JLD.jl still used until this pull request.
